### PR TITLE
[미들웨어]클라이언트 토큰 인증을 위한 Jwt 미들웨어 구현

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,6 +1,12 @@
+import { JwtMiddleware } from './jwt/jwt.middleware';
 import { User } from './user/entities/user.entity';
 import { GraphQLModule } from '@nestjs/graphql';
-import { Module } from '@nestjs/common';
+import {
+  Module,
+  NestModule,
+  MiddlewareConsumer,
+  RequestMethod,
+} from '@nestjs/common';
 import { join } from 'path';
 import * as Joi from 'joi';
 import { ConfigModule } from '@nestjs/config';
@@ -39,6 +45,7 @@ import { JwtModule } from './jwt/jwt.module';
     }),
     GraphQLModule.forRoot({
       autoSchemaFile: join(process.cwd(), 'src/schemas/schema.gql'),
+      context: ({ req }) => ({ user: req['user'] }),
     }),
     UserModule,
     CommonModule,
@@ -49,4 +56,11 @@ import { JwtModule } from './jwt/jwt.module';
   controllers: [],
   providers: [],
 })
-export class AppModule {}
+export class AppModule implements NestModule {
+  configure(consumer: MiddlewareConsumer) {
+    consumer.apply(JwtMiddleware).forRoutes({
+      path: '/graphql',
+      method: RequestMethod.ALL,
+    });
+  }
+}

--- a/src/jwt/jwt.middleware.ts
+++ b/src/jwt/jwt.middleware.ts
@@ -1,0 +1,28 @@
+import { UserService } from './../user/user.service';
+import { JwtService } from './jwt.service';
+import { NestMiddleware, Injectable } from '@nestjs/common';
+import { Request, Response, NextFunction } from 'express';
+
+@Injectable()
+export class JwtMiddleware implements NestMiddleware {
+  constructor(
+    private readonly jwtService: JwtService,
+    private readonly userService: UserService,
+  ) {}
+  async use(req: Request, res: Response, next: NextFunction) {
+    if ('jwt' in req.headers) {
+      const token = req.headers['x-jwt'];
+      try {
+        const decoded = this.jwtService.verify(token.toString());
+
+        if (typeof decoded === 'object' && decoded.hasOwnProperty('id')) {
+          const { user } = await this.userService.findById(decoded['id']);
+          req['user'] = user;
+        }
+      } catch (error) {
+        console.log(error);
+      }
+    }
+    next();
+  }
+}

--- a/src/user/user.module.ts
+++ b/src/user/user.module.ts
@@ -7,5 +7,6 @@ import { Module } from '@nestjs/common';
 @Module({
   imports: [TypeOrmModule.forFeature([User])],
   providers: [UserResolver, UserService],
+  exports: [UserService],
 })
 export class UserModule {}

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -4,7 +4,6 @@ import {
   CreateAccountInput,
   CreateAccountOutput,
 } from './dtos/create-account.dto';
-import * as jwt from 'jsonwebtoken';
 import { User } from './entities/user.entity';
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
@@ -81,5 +80,10 @@ export class UserService {
         error,
       };
     }
+  }
+
+  async findById(id: number): Promise<any> {
+    const user = await this.userRepository.findOneOrFail({ id });
+    return user;
   }
 }


### PR DESCRIPTION
### jwt 인증 미들 웨어 구현

- 클라이언트에서 오는 token을 인증하기 위해 미들웨어를 구현함
- 미들웨어 구현을 위해 `NestMiddleware` 인터페이스를 `implements` 한 클래스를 만든다.
- `express` 와 마찬가지로 미들웨어에서 `request` 를 처리한 다음에는 반드시 `next` 함수를 호출해 주어야 한다.
- 미들웨어가 전체 모듈에서 적용되도록하기 위해 `AppModule` 에 설정함
    - 미들웨어를 적용하기 위해 `AppModule` 은  `NestModule` 을 `implements` 한다. 인터페이스에 따라 `AppModule` 은 내부에 `configure` 프로퍼티를 가져야 하고, `consumer` 를 인자로 가진다. `consumer` 의 프로퍼티들을 이용해 미들웨어를 적용시킬 라우트를 정할 수 있다.
    - 즉 rest, graphql 등 다양한 api를 사용할 때, 미들웨어 별로 적용시킬 라우트와 제외 시킬 라우트를 설정할 수 있다.
- `jwtService` 의 메서드인 `login` 시, `token` 을 발급할 때, 유저의 `id` 값을 넘겨주고 있으므로, 토큰을 인증할 때도 id값으로 인증한다.
- `JwtMiddleware` 내부에서 `UserService` 클래스의 메서드가 필요하므로, `User` 모듈 클래스에서 `exports` 해준다. 그래야 의존성 주입이 가능하다.
- `req` 에 `['user']` 필드를 만들어서 token을 통해 찾아낸 유저 정보를 넣어준다.
- 유저 정보를 가진 `request` 는 미들웨어를 통과하여 graphql 서버인 `apollo server` 에 도달한다. 아폴로 서버에서 리퀘스트를 받기 위해 `context`를 함수로 정의하여, 매 리퀘스트마다 호출되도록 한다. context에 정의된 함수는 매 요청마다 호출되며, **req 프로퍼티를 포함한 객체**를 express로 부터 받을 수 있다. 더 자세한 사항은 여기를 [참고](https://github.com/apollographql/apollo-server)
- 컨텍스트에 정의된 함수가 프로퍼티를 반환하면, 이 프로퍼티는 `resolver` 내부에서 사용할 수 있다. 이를 통해 `JwtMiddleware` 를 통과하면서 얻은 토큰 기반 유저 정보를 resolver에 전달할 수 있는 것이다.

```tsx
// app.module
GraphQLModule.forRoot({
      autoSchemaFile: join(process.cwd(), 'src/schemas/schema.gql'),
      context: ({ req }) => ({ user: req['user'] }),
    }),
```