### PR TITLE
[User]유저 관련 리졸버 추가 작성

### DIFF
--- a/src/jwt/jwt.middleware.ts
+++ b/src/jwt/jwt.middleware.ts
@@ -11,7 +11,7 @@ export class JwtMiddleware implements NestMiddleware {
   ) {}
   async use(req: Request, res: Response, next: NextFunction) {
     if ('jwt' in req.headers) {
-      const token = req.headers['x-jwt'];
+      const token = req.headers['jwt'];
       try {
         const decoded = this.jwtService.verify(token.toString());
 

--- a/src/schemas/schema.gql
+++ b/src/schemas/schema.gql
@@ -31,6 +31,12 @@ enum UserRole {
   sitter
 }
 
+type UserProfileOutput {
+  error: String
+  isSucceeded: Boolean!
+  user: User
+}
+
 type LoginOutput {
   error: String
   isSucceeded: Boolean!
@@ -44,6 +50,7 @@ type CreateAccountOutput {
 
 type Query {
   me: User!
+  userProfile(userId: Float!): UserProfileOutput!
 }
 
 type Mutation {

--- a/src/schemas/schema.gql
+++ b/src/schemas/schema.gql
@@ -31,6 +31,16 @@ enum UserRole {
   sitter
 }
 
+type ChangePasswordOutput {
+  error: String
+  isSucceeded: Boolean!
+}
+
+type EditProfileOutput {
+  error: String
+  isSucceeded: Boolean!
+}
+
 type UserProfileOutput {
   error: String
   isSucceeded: Boolean!
@@ -56,6 +66,8 @@ type Query {
 type Mutation {
   createAccount(input: CreateAccountInput!): CreateAccountOutput!
   login(input: LoginInput!): LoginOutput!
+  editProfile(input: EditProfileInput!): EditProfileOutput!
+  changePassword(input: ChangePasswordInput!): ChangePasswordOutput!
 }
 
 input CreateAccountInput {
@@ -70,5 +82,14 @@ input CreateAccountInput {
 
 input LoginInput {
   accountId: String!
+  password: String!
+}
+
+input EditProfileInput {
+  name: String
+  email: String
+}
+
+input ChangePasswordInput {
   password: String!
 }

--- a/src/user/dtos/change-password.dto.ts
+++ b/src/user/dtos/change-password.dto.ts
@@ -1,0 +1,9 @@
+import { User } from './../entities/user.entity';
+import { ObjectType, PickType, InputType } from '@nestjs/graphql';
+import { CoreOutput } from './../../common/dtos/output.dto';
+
+@ObjectType()
+export class ChangePasswordOutput extends CoreOutput {}
+
+@InputType()
+export class ChangePasswordInput extends PickType(User, ['password']) {}

--- a/src/user/dtos/edit-profile.dto.ts
+++ b/src/user/dtos/edit-profile.dto.ts
@@ -1,0 +1,11 @@
+import { User } from './../entities/user.entity';
+import { ObjectType, PickType, PartialType, InputType } from '@nestjs/graphql';
+import { CoreOutput } from './../../common/dtos/output.dto';
+
+@ObjectType()
+export class EditProfileOutput extends CoreOutput {}
+
+@InputType()
+export class EditProfileInput extends PartialType(
+  PickType(User, ['email', 'name']),
+) {}

--- a/src/user/dtos/user-profile.dto.ts
+++ b/src/user/dtos/user-profile.dto.ts
@@ -1,0 +1,15 @@
+import { User } from './../entities/user.entity';
+import { CoreOutput } from './../../common/dtos/output.dto';
+import { ArgsType, Field, ObjectType } from '@nestjs/graphql';
+
+@ArgsType()
+export class UserProfileInput {
+  @Field(() => Number)
+  userId: number;
+}
+
+@ObjectType()
+export class UserProfileOutput extends CoreOutput {
+  @Field(() => User, { nullable: true })
+  user?: User;
+}

--- a/src/user/entities/user.entity.ts
+++ b/src/user/entities/user.entity.ts
@@ -6,7 +6,7 @@ import {
 } from '@nestjs/graphql';
 import { CoreEntity } from './../../common/entities/core.entity';
 import { InternalServerErrorException } from '@nestjs/common';
-import { Entity, Column, BeforeInsert } from 'typeorm';
+import { Entity, Column, BeforeInsert, BeforeUpdate } from 'typeorm';
 import {
   IsEmail,
   IsString,
@@ -77,6 +77,7 @@ export class User extends CoreEntity {
   role: UserRole[];
 
   @BeforeInsert()
+  @BeforeUpdate()
   async hashPassword(): Promise<void> {
     try {
       this.password = await bcrypt.hash(this.password, 10);

--- a/src/user/user.resolver.ts
+++ b/src/user/user.resolver.ts
@@ -1,3 +1,8 @@
+import {
+  ChangePasswordOutput,
+  ChangePasswordInput,
+} from './dtos/change-password.dto';
+import { EditProfileOutput, EditProfileInput } from './dtos/edit-profile.dto';
 import { UserProfileInput, UserProfileOutput } from './dtos/user-profile.dto';
 import { AuthUser } from './../auth/auth-user.decorator';
 import { AuthGuard } from './../auth/auth.guard';
@@ -39,5 +44,23 @@ export class UserResolver {
   @Mutation(() => LoginOutput)
   async login(@Args('input') loginInput: LoginInput): Promise<LoginOutput> {
     return this.userService.login(loginInput);
+  }
+
+  @UseGuards(AuthGuard)
+  @Mutation(() => EditProfileOutput)
+  async editProfile(
+    @AuthUser() authUser: User,
+    @Args('input') editProfileInput: EditProfileInput,
+  ): Promise<EditProfileOutput> {
+    return this.userService.editProfile(authUser.id, editProfileInput);
+  }
+
+  @UseGuards(AuthGuard)
+  @Mutation(() => ChangePasswordOutput)
+  async changePassword(
+    @AuthUser() authUser: User,
+    @Args('input') { password }: ChangePasswordInput,
+  ): Promise<ChangePasswordOutput> {
+    return this.userService.changePassword(authUser.id, password);
   }
 }

--- a/src/user/user.resolver.ts
+++ b/src/user/user.resolver.ts
@@ -1,3 +1,4 @@
+import { UserProfileInput, UserProfileOutput } from './dtos/user-profile.dto';
 import { AuthUser } from './../auth/auth-user.decorator';
 import { AuthGuard } from './../auth/auth.guard';
 import { LoginOutput, LoginInput } from './dtos/login.dto';
@@ -18,6 +19,14 @@ export class UserResolver {
   @UseGuards(AuthGuard)
   me(@AuthUser() authUser: User) {
     return authUser;
+  }
+
+  @UseGuards(AuthGuard)
+  @Query(() => UserProfileOutput)
+  async userProfile(
+    @Args() userProfileInput: UserProfileInput,
+  ): Promise<UserProfileOutput> {
+    return this.userService.findById(userProfileInput.userId);
   }
 
   @Mutation(() => CreateAccountOutput)

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -1,3 +1,4 @@
+import { UserProfileOutput } from './dtos/user-profile.dto';
 import { JwtService } from './../jwt/jwt.service';
 import { LoginInput, LoginOutput } from './dtos/login.dto';
 import {
@@ -82,8 +83,18 @@ export class UserService {
     }
   }
 
-  async findById(id: number): Promise<any> {
-    const user = await this.userRepository.findOneOrFail({ id });
-    return user;
+  async findById(id: number): Promise<UserProfileOutput> {
+    try {
+      const user = await this.userRepository.findOneOrFail({ id });
+      return {
+        isSucceeded: true,
+        user,
+      };
+    } catch (error) {
+      return {
+        isSucceeded: false,
+        error: 'User Not Found',
+      };
+    }
   }
 }

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -1,3 +1,5 @@
+import { ChangePasswordOutput } from './dtos/change-password.dto';
+import { EditProfileOutput, EditProfileInput } from './dtos/edit-profile.dto';
 import { UserProfileOutput } from './dtos/user-profile.dto';
 import { JwtService } from './../jwt/jwt.service';
 import { LoginInput, LoginOutput } from './dtos/login.dto';
@@ -94,6 +96,45 @@ export class UserService {
       return {
         isSucceeded: false,
         error: 'User Not Found',
+      };
+    }
+  }
+
+  async editProfile(
+    userId: number,
+    editProfileInput: EditProfileInput,
+  ): Promise<EditProfileOutput> {
+    try {
+      await this.userRepository.update(userId, {
+        ...editProfileInput,
+      });
+      return {
+        isSucceeded: true,
+      };
+    } catch (error) {
+      return {
+        isSucceeded: false,
+        error,
+      };
+    }
+  }
+
+  async changePassword(
+    userId: number,
+    password: string,
+  ): Promise<ChangePasswordOutput> {
+    try {
+      const user = await this.userRepository.findOne(userId);
+      user.password = password;
+      await this.userRepository.save(user);
+
+      return {
+        isSucceeded: true,
+      };
+    } catch (error) {
+      return {
+        isSucceeded: false,
+        error,
       };
     }
   }


### PR DESCRIPTION
토큰이 필요한 모든 쿼리 및 뮤테이션에 `@UseGaurds(AuthGuard)` 를 적용하여 토큰 인증 및 유저 인증을 진행한다.

### userProfile 쿼리

- `userId` 를 기반으로 유저 정보를 열람할 수 있는 쿼리

### updateProfile 뮤테이션

- `updateProfileInput` dto의 경우, 원하는 정보만 수정할 수 있도록, `PartialType` 과 `PickType` 을 조합하여 원하는 필드만 옵셔널하게 수정가능하도록 함.
    - 실제 수정할 정보만 업데이트 할 수 있도록 변경불가 필드들은 추가하지 않음
- `update` 메서드의 경우, 빠르기는 하지만 db에 실제 데이터가 있는지 확인하지 않는다. 즉 엔티티를 불러오지도 않고 db에 sql을 보내기만 한다. 따라서 `User` 엔티티에 설정해둔 `BeforeUpdate()` 데코레이터가 발동되지 않는다.  만약 비밀번호를 변경할 경우, 변경된 비밀번호는 해싱되지 않고 그대로 db에 저장되게 된다.   `BeforeUpdate()` 는 오직 특정 `entity` 가 업데이트 될때만 호출된다. 따라서 비밀번호 변경 리졸버는 따로 작성한다.
- 비밀번호를 제외한 나머지 정보들은, 인자로 들어온 userId가 이미 미들웨어와 가드를 거쳐서 들어왔기 때문에, 이 정보를 신뢰하여 바로 업데이트를 실행한다.

### ChangePassword 뮤테이션

안전한 비밀번호 변경을 위해 `changePassword` 뮤테이션을 따로 작성하고, `save` 메서드로 업데이트하여, 해쉬함수가 적용되도록 함.