### PR TITLE
[유저]부모 회원과 시터 회원 뮤테이션 분리 및 `children` 엔티티 추가 + 비밀번호 유효성 검사

### DIFF
--- a/src/schemas/schema.gql
+++ b/src/schemas/schema.gql
@@ -9,7 +9,7 @@ type User {
   memberNumber: Float!
   name: String!
   birthday: DateTime!
-  sex: SexType!
+  gender: GenderType!
   accountId: String!
   password: String!
   email: String!
@@ -25,7 +25,7 @@ A date-time string at UTC, such as 2019-12-03T09:54:33Z, compliant with the date
 """
 scalar DateTime
 
-enum SexType {
+enum GenderType {
   MALE
   FEMALE
 }
@@ -46,8 +46,18 @@ type Child {
   createdAt: DateTime!
   updatedAt: DateTime!
   birthday: DateTime!
-  sex: SexType!
+  gender: GenderType!
   parent: User!
+}
+
+type CreateAccountOfSitterOutput {
+  error: String
+  isSucceeded: Boolean!
+}
+
+type CreateAccountOfMomOutput {
+  error: String
+  isSucceeded: Boolean!
 }
 
 type AddParentRoleOutput {
@@ -77,32 +87,46 @@ type LoginOutput {
   token: String
 }
 
-type CreateAccountOutput {
-  error: String
-  isSucceeded: Boolean!
-}
-
 type Query {
   me: User!
   userProfile(userId: Float!): UserProfileOutput!
 }
 
 type Mutation {
-  createAccount(input: CreateAccountInput!): CreateAccountOutput!
+  createAccountOfMom(childen: ChildrenInput!, mom: CreateAccountOfMomInput!): CreateAccountOfMomOutput!
+  createAccountOfSitter(input: CreateAccountOfSitterInput!): CreateAccountOfSitterOutput!
   login(input: LoginInput!): LoginOutput!
   updateProfile(input: UpdateProfileInput!): UpdateProfileOutput!
   changePassword(input: ChangePasswordInput!): ChangePasswordOutput!
   addParentRole(input: AddParentRoleInput!): AddParentRoleOutput!
 }
 
-input CreateAccountInput {
+input ChildrenInput {
+  birthday: DateTime!
+  gender: GenderType!
+}
+
+input CreateAccountOfMomInput {
   name: String!
   birthday: DateTime!
-  sex: SexType!
+  gender: GenderType!
   accountId: String!
   password: String!
   email: String!
   roles: [UserRole!]!
+  parentDescription: String
+}
+
+input CreateAccountOfSitterInput {
+  name: String!
+  birthday: DateTime!
+  gender: GenderType!
+  accountId: String!
+  password: String!
+  email: String!
+  roles: [UserRole!]!
+  sitterDescription: String
+  careRange: [CareRange!]!
 }
 
 input LoginInput {
@@ -113,15 +137,15 @@ input LoginInput {
 input UpdateProfileInput {
   name: String
   email: String
-  children: [chlidEntity!]
+  children: [ChildEntity!]
   parentDescription: String
   sitterDescription: String
   careRange: [CareRange!]
 }
 
-input chlidEntity {
+input ChildEntity {
   birthday: DateTime!
-  sex: SexType!
+  gender: GenderType!
   parent: UserEntity!
 }
 
@@ -129,12 +153,12 @@ input UserEntity {
   memberNumber: Float!
   name: String!
   birthday: DateTime!
-  sex: SexType!
+  gender: GenderType!
   accountId: String!
   password: String!
   email: String!
   roles: [UserRole!]!
-  children: [chlidEntity!]
+  children: [ChildEntity!]
   parentDescription: String
   sitterDescription: String
   careRange: [CareRange!]!
@@ -145,6 +169,6 @@ input ChangePasswordInput {
 }
 
 input AddParentRoleInput {
-  children: [chlidEntity!]
+  children: [ChildEntity!]
   parentDescription: String
 }

--- a/src/user/dtos/change-password.dto.ts
+++ b/src/user/dtos/change-password.dto.ts
@@ -2,8 +2,7 @@ import { User } from './../entities/user.entity';
 import { ObjectType, PickType, InputType } from '@nestjs/graphql';
 import { CoreOutput } from './../../common/dtos/output.dto';
 
-@ObjectType()
-export class ChangePasswordOutput extends CoreOutput {}
-
 @InputType()
 export class ChangePasswordInput extends PickType(User, ['password']) {}
+@ObjectType()
+export class ChangePasswordOutput extends CoreOutput {}

--- a/src/user/dtos/create-account-of-mom.dto.ts
+++ b/src/user/dtos/create-account-of-mom.dto.ts
@@ -1,0 +1,22 @@
+import { Child } from './../entities/child.entity';
+import { CoreOutput } from './../../common/dtos/output.dto';
+import { User } from './../entities/user.entity';
+import { PickType, ObjectType, InputType } from '@nestjs/graphql';
+
+@InputType()
+export class CreateAccountOfMomInput extends PickType(User, [
+  'birthday',
+  'email',
+  'name',
+  'password',
+  'roles',
+  'gender',
+  'accountId',
+  'parentDescription',
+]) {}
+
+@InputType()
+export class ChildrenInput extends PickType(Child, ['birthday', 'gender']) {}
+
+@ObjectType()
+export class CreateAccountOfMomOutput extends CoreOutput {}

--- a/src/user/dtos/create-account-of-sitter.dto.ts
+++ b/src/user/dtos/create-account-of-sitter.dto.ts
@@ -3,15 +3,17 @@ import { User } from './../entities/user.entity';
 import { PickType, ObjectType, InputType } from '@nestjs/graphql';
 
 @InputType()
-export class CreateAccountInput extends PickType(User, [
+export class CreateAccountOfSitterInput extends PickType(User, [
   'birthday',
   'email',
   'name',
   'password',
   'roles',
-  'sex',
+  'gender',
   'accountId',
+  'careRange',
+  'sitterDescription',
 ]) {}
 
 @ObjectType()
-export class CreateAccountOutput extends CoreOutput {}
+export class CreateAccountOfSitterOutput extends CoreOutput {}

--- a/src/user/dtos/update-profile.dto.ts
+++ b/src/user/dtos/update-profile.dto.ts
@@ -2,9 +2,6 @@ import { User } from './../entities/user.entity';
 import { ObjectType, PickType, PartialType, InputType } from '@nestjs/graphql';
 import { CoreOutput } from './../../common/dtos/output.dto';
 
-@ObjectType()
-export class UpdateProfileOutput extends CoreOutput {}
-
 @InputType()
 export class UpdateProfileInput extends PartialType(
   PickType(User, [
@@ -16,3 +13,6 @@ export class UpdateProfileInput extends PartialType(
     'sitterDescription',
   ]),
 ) {}
+
+@ObjectType()
+export class UpdateProfileOutput extends CoreOutput {}

--- a/src/user/entities/child.entity.ts
+++ b/src/user/entities/child.entity.ts
@@ -1,27 +1,25 @@
-import { SexType, User } from './user.entity';
-import { Field, InputType, ObjectType } from '@nestjs/graphql';
-import { IsEnum, IsDate } from 'class-validator';
+import { User } from './user.entity';
 import { CoreEntity } from './../../common/entities/core.entity';
-import { Column, Entity, ManyToOne, RelationId } from 'typeorm';
+import { IsEnum, IsDate } from 'class-validator';
+import { Column, Entity, ManyToOne } from 'typeorm';
+import { GenderType } from './../entities/user.entity';
+import { ObjectType, InputType, Field } from '@nestjs/graphql';
 
-@InputType('chlidEntity', { isAbstract: true })
+@InputType('ChildEntity', { isAbstract: true })
 @ObjectType()
 @Entity()
 export class Child extends CoreEntity {
   @Column()
-  @Field(() => Date)
   @IsDate()
+  @Field(() => Date)
   birthday: Date;
 
-  @Column({ type: 'enum', enum: SexType })
-  @Field(() => SexType)
-  @IsEnum(SexType)
-  sex: SexType;
+  @Column({ type: 'enum', enum: GenderType })
+  @Field(() => GenderType)
+  @IsEnum(GenderType)
+  gender: GenderType;
 
   @Field(() => User)
   @ManyToOne(() => User, (user) => user.children, { onDelete: 'CASCADE' })
   parent: User;
-
-  @RelationId((child: Child) => child.parent)
-  parentId: number;
 }

--- a/src/user/entities/user.entity.ts
+++ b/src/user/entities/user.entity.ts
@@ -16,11 +16,10 @@ import {
   IsDate,
   Length,
   IsOptional,
-  IsArray,
 } from 'class-validator';
 import * as bcrypt from 'bcrypt';
 
-export enum SexType {
+export enum GenderType {
   MALE = 'MALE',
   FEMALE = 'FEMALE',
 }
@@ -36,15 +35,14 @@ enum CareRange {
 }
 
 registerEnumType(UserRole, { name: 'UserRole' });
-registerEnumType(SexType, { name: 'SexType' });
+registerEnumType(GenderType, { name: 'GenderType' });
 registerEnumType(CareRange, { name: 'CareRange' });
 
 @InputType('UserEntity', { isAbstract: true })
 @ObjectType()
 @Entity()
 export class User extends CoreEntity {
-  //TODO: 유니크 키로 자동 생성되로록 바꾸기
-  @Column({ default: 1111, unique: true })
+  @Column({ unique: true })
   @Field(() => Number)
   @IsNumber()
   memberNumber: number;
@@ -59,10 +57,10 @@ export class User extends CoreEntity {
   @IsDate()
   birthday: Date;
 
-  @Column({ type: 'enum', enum: SexType })
-  @Field(() => SexType)
-  @IsEnum(SexType)
-  sex: SexType;
+  @Column({ type: 'enum', enum: GenderType })
+  @Field(() => GenderType)
+  @IsEnum(GenderType)
+  gender: GenderType;
 
   @Column({ unique: true })
   @Field(() => String)
@@ -87,10 +85,8 @@ export class User extends CoreEntity {
   @IsEnum(UserRole, { each: true })
   roles: UserRole[];
 
-  @OneToMany(() => Child, (child) => child.parentId, { nullable: true })
+  @OneToMany(() => Child, (child) => child.parent, { nullable: true })
   @Field(() => [Child], { nullable: true })
-  @IsOptional()
-  @IsArray()
   children?: Child[];
 
   @Column({ nullable: true })
@@ -119,6 +115,11 @@ export class User extends CoreEntity {
     } catch (error) {
       throw new InternalServerErrorException();
     }
+  }
+
+  @BeforeInsert()
+  generateMemberNumber(): void {
+    this.memberNumber = Math.floor(Math.random() * 100);
   }
 
   async checkPassword(password: string): Promise<boolean> {

--- a/src/user/user.module.ts
+++ b/src/user/user.module.ts
@@ -1,3 +1,4 @@
+import { Child } from './entities/child.entity';
 import { User } from './entities/user.entity';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { UserService } from './user.service';
@@ -5,7 +6,7 @@ import { UserResolver } from './user.resolver';
 import { Module } from '@nestjs/common';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([User])],
+  imports: [TypeOrmModule.forFeature([User, Child])],
   providers: [UserResolver, UserService],
   exports: [UserService],
 })

--- a/src/user/user.resolver.ts
+++ b/src/user/user.resolver.ts
@@ -1,3 +1,12 @@
+import {
+  CreateAccountOfSitterInput,
+  CreateAccountOfSitterOutput,
+} from './dtos/create-account-of-sitter.dto';
+import {
+  CreateAccountOfMomInput,
+  CreateAccountOfMomOutput,
+  ChildrenInput,
+} from './dtos/create-account-of-mom.dto';
 import { Role } from './../auth/role.decorator';
 import {
   AddParentRoleInput,
@@ -15,10 +24,6 @@ import { UserProfileInput, UserProfileOutput } from './dtos/user-profile.dto';
 import { AuthUser } from './../auth/auth-user.decorator';
 import { AuthGuard } from './../auth/auth.guard';
 import { LoginOutput, LoginInput } from './dtos/login.dto';
-import {
-  CreateAccountInput,
-  CreateAccountOutput,
-} from './dtos/create-account.dto';
 import { UserService } from './user.service';
 import { User, UserRole } from './entities/user.entity';
 import { Resolver, Mutation, Args, Query } from '@nestjs/graphql';
@@ -42,11 +47,22 @@ export class UserResolver {
     return this.userService.findById(userProfileInput.userId);
   }
 
-  @Mutation(() => CreateAccountOutput)
-  async createAccount(
-    @Args('input') createAccountInput: CreateAccountInput,
-  ): Promise<CreateAccountOutput> {
-    return this.userService.createAccount(createAccountInput);
+  @Mutation(() => CreateAccountOfMomOutput)
+  async createAccountOfMom(
+    @Args('mom') createAccountOfMomInput: CreateAccountOfMomInput,
+    @Args('childen') childrenInput: ChildrenInput,
+  ): Promise<CreateAccountOfMomOutput> {
+    return this.userService.createAccountOfMom(
+      createAccountOfMomInput,
+      childrenInput,
+    );
+  }
+
+  @Mutation(() => CreateAccountOfSitterOutput)
+  async createAccountOfSitter(
+    @Args('input') createAccountOfSitterInput: CreateAccountOfSitterInput,
+  ): Promise<CreateAccountOfSitterOutput> {
+    return this.userService.createAccountOfSitter(createAccountOfSitterInput);
   }
 
   @Mutation(() => LoginOutput)

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -71,7 +71,7 @@ export class UserService {
       console.log(error);
       return {
         isSucceeded: false,
-        error: "Couldn't create an account",
+        error,
       };
     }
   }
@@ -106,7 +106,7 @@ export class UserService {
       console.log(error);
       return {
         isSucceeded: false,
-        error: "Couldn't create an account",
+        error,
       };
     }
   }
@@ -155,7 +155,7 @@ export class UserService {
     } catch (error) {
       return {
         isSucceeded: false,
-        error: 'User Not Found',
+        error,
       };
     }
   }

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -1,3 +1,13 @@
+import { Child } from './entities/child.entity';
+import {
+  CreateAccountOfSitterInput,
+  CreateAccountOfSitterOutput,
+} from './dtos/create-account-of-sitter.dto';
+import {
+  CreateAccountOfMomInput,
+  CreateAccountOfMomOutput,
+  ChildrenInput,
+} from './dtos/create-account-of-mom.dto';
 import {
   AddParentRoleOutput,
   AddParentRoleInput,
@@ -10,10 +20,6 @@ import {
 import { UserProfileOutput } from './dtos/user-profile.dto';
 import { JwtService } from './../jwt/jwt.service';
 import { LoginInput, LoginOutput } from './dtos/login.dto';
-import {
-  CreateAccountInput,
-  CreateAccountOutput,
-} from './dtos/create-account.dto';
 import { User } from './entities/user.entity';
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
@@ -23,16 +29,18 @@ import { Repository } from 'typeorm';
 export class UserService {
   constructor(
     @InjectRepository(User) private readonly userRepository: Repository<User>,
+    @InjectRepository(Child)
+    private readonly childRepository: Repository<Child>,
     private readonly jwtService: JwtService,
   ) {}
 
-  async createAccount(
-    createAccountInput: CreateAccountInput,
-  ): Promise<CreateAccountOutput> {
-    const { accountId } = createAccountInput;
+  async createAccountOfMom(
+    createAccountOfMonInput: CreateAccountOfMomInput,
+    childrenInput: ChildrenInput,
+  ): Promise<CreateAccountOfMomOutput> {
+    const { accountId, roles } = createAccountOfMonInput;
     try {
       const exists = await this.userRepository.findOne({ accountId });
-
       if (exists) {
         return {
           isSucceeded: false,
@@ -40,15 +48,62 @@ export class UserService {
         };
       }
 
+      if (roles[0] !== 'PARENT') {
+        return {
+          isSucceeded: false,
+          error: 'You should set your role to PARENT',
+        };
+      }
+      const newUser = this.userRepository.create({
+        ...createAccountOfMonInput,
+      });
+      await this.userRepository.save(newUser);
+
+      const newChildren = this.childRepository.create({ ...childrenInput });
+      newChildren.parent = newUser;
+
+      await this.childRepository.save(newChildren);
+
+      return {
+        isSucceeded: true,
+      };
+    } catch (error) {
+      console.log(error);
+      return {
+        isSucceeded: false,
+        error: "Couldn't create an account",
+      };
+    }
+  }
+
+  async createAccountOfSitter(
+    createAccountOfSitterInput: CreateAccountOfSitterInput,
+  ): Promise<CreateAccountOfSitterOutput> {
+    const { accountId, roles } = createAccountOfSitterInput;
+    try {
+      const exists = await this.userRepository.findOne({ accountId });
+      if (exists) {
+        return {
+          isSucceeded: false,
+          error: 'There is an user with that email already',
+        };
+      }
+
+      if (roles[0] !== 'SITTER') {
+        return {
+          isSucceeded: false,
+          error: 'You should set your role to PARENT',
+        };
+      }
+
       await this.userRepository.save(
-        this.userRepository.create({ ...createAccountInput }),
+        this.userRepository.create({ ...createAccountOfSitterInput }),
       );
       return {
         isSucceeded: true,
       };
     } catch (error) {
       console.log(error);
-
       return {
         isSucceeded: false,
         error: "Couldn't create an account",

--- a/src/utils/validate-password.ts
+++ b/src/utils/validate-password.ts
@@ -1,0 +1,9 @@
+export const validatePassword = (password: string): boolean => {
+  const isNumber = password.search(/[0-9]/g);
+  const isAlphabet = password.search(/[a-z]/gi);
+
+  if (isNumber < 0 || isAlphabet < 0) {
+    return false;
+  }
+  return true;
+};


### PR DESCRIPTION
### Child 엔티티 생성

- `User` 엔티티는 많은 `Child` 엔티티를 가질 수 잇고, `Child` 엔티티는 반드시 `User` 엔티티를 부모로 가지고 있어야 한다. 또한 `Child` 엔티티만 별도로 만들 수 없고, 회원가입 시, `Child` 정보가 넘어올 때만 생성되기 때문에 `nullable` 로 처리

### 비밀번호 유효성 검사
`User` 엔티티의 `hashPassword` 함수 내부에 비밀번호 유효성 검사를 추가해서, 비밀번호가 삽입되거나 업데이트 되기 전, 정책 검사를 하고 해쉬함수를 적용하도록 변경