### PR TITLE
[유저]추가 정보를 통한 역할 추가 리졸버 추가

### DIFF
--- a/src/schemas/schema.gql
+++ b/src/schemas/schema.gql
@@ -50,6 +50,11 @@ type Child {
   parent: User!
 }
 
+type AddSitterRoleOutput {
+  error: String
+  isSucceeded: Boolean!
+}
+
 type CreateAccountOfSitterOutput {
   error: String
   isSucceeded: Boolean!
@@ -98,7 +103,8 @@ type Mutation {
   login(input: LoginInput!): LoginOutput!
   updateProfile(input: UpdateProfileInput!): UpdateProfileOutput!
   changePassword(input: ChangePasswordInput!): ChangePasswordOutput!
-  addParentRole(input: AddParentRoleInput!): AddParentRoleOutput!
+  addParentRole(childen: ChildrenInput!, input: AddParentRoleInput!): AddParentRoleOutput!
+  addSitterRole(input: AddSitterRoleInput!): AddSitterRoleOutput!
 }
 
 input ChildrenInput {
@@ -169,6 +175,10 @@ input ChangePasswordInput {
 }
 
 input AddParentRoleInput {
-  children: [ChildEntity!]
   parentDescription: String
+}
+
+input AddSitterRoleInput {
+  sitterDescription: String
+  careRange: [CareRange!]!
 }

--- a/src/user/dtos/add-sitter-role.dto.ts
+++ b/src/user/dtos/add-sitter-role.dto.ts
@@ -3,7 +3,10 @@ import { User } from './../entities/user.entity';
 import { PickType, ObjectType, InputType } from '@nestjs/graphql';
 
 @InputType()
-export class AddParentRoleInput extends PickType(User, ['parentDescription']) {}
+export class AddSitterRoleInput extends PickType(User, [
+  'sitterDescription',
+  'careRange',
+]) {}
 
 @ObjectType()
-export class AddParentRoleOutput extends CoreOutput {}
+export class AddSitterRoleOutput extends CoreOutput {}

--- a/src/user/dtos/update-profile.dto.ts
+++ b/src/user/dtos/update-profile.dto.ts
@@ -11,6 +11,7 @@ export class UpdateProfileInput extends PartialType(
     'children',
     'parentDescription',
     'sitterDescription',
+    'careRange',
   ]),
 ) {}
 

--- a/src/user/entities/user.entity.ts
+++ b/src/user/entities/user.entity.ts
@@ -69,7 +69,7 @@ export class User extends CoreEntity {
   @IsOptional()
   @IsString()
   @MinLength(5)
-  @MaxLength(15)
+  @MaxLength(20)
   accountId: string;
 
   @Column()

--- a/src/user/user.resolver.ts
+++ b/src/user/user.resolver.ts
@@ -1,4 +1,8 @@
 import {
+  AddSitterRoleOutput,
+  AddSitterRoleInput,
+} from './dtos/add-sitter-role.dto';
+import {
   CreateAccountOfSitterInput,
   CreateAccountOfSitterOutput,
 } from './dtos/create-account-of-sitter.dto';
@@ -22,12 +26,10 @@ import {
 } from './dtos/update-profile.dto';
 import { UserProfileInput, UserProfileOutput } from './dtos/user-profile.dto';
 import { AuthUser } from './../auth/auth-user.decorator';
-import { AuthGuard } from './../auth/auth.guard';
 import { LoginOutput, LoginInput } from './dtos/login.dto';
 import { UserService } from './user.service';
 import { User, UserRole } from './entities/user.entity';
 import { Resolver, Mutation, Args, Query } from '@nestjs/graphql';
-import { UseGuards } from '@nestjs/common';
 
 @Resolver(() => User)
 export class UserResolver {
@@ -79,8 +81,8 @@ export class UserResolver {
     return this.userService.updateProfile(authUser.id, editProfileInput);
   }
 
-  @UseGuards(AuthGuard)
   @Mutation(() => ChangePasswordOutput)
+  @Role(['Any'])
   async changePassword(
     @AuthUser() authUser: User,
     @Args('input') { password }: ChangePasswordInput,
@@ -93,7 +95,21 @@ export class UserResolver {
   async addParentRole(
     @AuthUser() authUser: User,
     @Args('input') addParentRoleInput: AddParentRoleInput,
+    @Args('childen') childrenInput: ChildrenInput,
   ): Promise<AddParentRoleOutput> {
-    return this.userService.addParentRole(authUser.id, addParentRoleInput);
+    return this.userService.addParentRole(
+      authUser.id,
+      addParentRoleInput,
+      childrenInput,
+    );
+  }
+
+  @Mutation(() => AddSitterRoleOutput)
+  @Role([UserRole.PARENT])
+  async addSitterRole(
+    @AuthUser() authUser: User,
+    @Args('input') addSitterRoleInput: AddSitterRoleInput,
+  ): Promise<AddSitterRoleOutput> {
+    return this.userService.addSitterRole(authUser.id, addSitterRoleInput);
   }
 }


### PR DESCRIPTION
`addParentRole`과 `addSitterRole`은 거의 유사하게 만들어졌음
- `@Role()` 데코레이터로 유저가 가지고 있는 역할을 파악한 후, 부모회원은 `addSitterRole`만 요청할 수 있고 시터회원은 `addParentRole`만 요청할 수 있다. 
- 만약 이미 두 역할을 모두 가지고 있어서, `@Role()` 데코레이터를 통과하더라고, 서비스 메서드 내부에서 유저 아이디로 실제 저장되어 있는 유저의 역할 정보를 불러와서, 이미 두 역할을 모두 가지고 있다면 에러를 리턴한다.
- 이후 각 뮤테이션에 맞는 역할을 주입해준 후, 나머지 연산자를 통해 인자를 넘겨주어 `update` 를 실행한다.